### PR TITLE
Fix udev rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DIRNAME=/tmp/$(VERNAME)
 acdcontrol: acdcontrol.cpp
 
 99-acdcontrol.rules: acdcontrol
-	./acdcontrol -l | sed --r -e 's/Vendor= 0x([0-9a-f]*) \(.*\), Product=0x([0-9a-f]*) \[(.*)\]/\# \3\nATTR{idVendor}=\"\1\", ATTR{idProduct}=\"\2\", MODE=\"0666\"/g' > 99-acdcontrol.rules
+	./acdcontrol -l | sed --r -e 's/Vendor= 0x([0-9a-f]*) \(.*\), Product=0x([0-9a-f]*) \[(.*)\]/\# \3\nATTR{idVendor}==\"\1\", ATTR{idProduct}==\"\2\", MODE=\"0666\"/g' > 99-acdcontrol.rules
 
 release:
 	mkdir -p $(DIRNAME)


### PR DESCRIPTION
Change udev rules from `ATTR{idProduct}=[...]` to  `ATTR{idProduct}==[...]`.
A single `=` tells udev to write to the idProduct attribute and results in a ton of startup errors of the form:

```
error opening ATTR{/sys/devices/virtual/sound/timer/idVendor} for writing: Permission denied
error opening ATTR{/sys/devices/virtual/sound/timer/idProduct} for writing: Permission denied
error opening ATTR{/sys/devices/virtual/sound/timer/idVendor} for writing: Permission denied
error opening ATTR{/sys/devices/virtual/sound/timer/idProduct} for writing: Permission denied
error opening ATTR{/sys/devices/virtual/sound/timer/idVendor} for writing: Permission denied
...
```