### PR TITLE
(fix) Update maximum brightness cap

### DIFF
--- a/acdcontrol.cpp
+++ b/acdcontrol.cpp
@@ -490,7 +490,7 @@ int main (int argc, char **argv) {
       if ( mode == SETREL ) {
         brightness = usage_ref.value + amount;
         brightness = max( 0, brightness);
-        brightness = min( 750, brightness);
+        brightness = min( 1000, brightness);
         usage_ref.value = brightness;
         
         /* set calculated brightness */


### PR DESCRIPTION
- Bump maximum brightness to 1000

I'm using an Apple Cinema 27" DisplayPort (not Thunderbolt) and my maximum brightness is 1000.